### PR TITLE
Extended functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,23 @@ A tool for finding duplicate files.
 
 # Usage
 
-Give it a directory to search in (called the haystack) and one or more files to search for (called the needles).
+Give it a directory to search in (called the haystack) and one or more files (or directories) to search for (called the needles).
 
     find-dups [options] haystack needle...
 
     -h, --help
     -v, --[no-]verbose
-    -p, --print         Print 'needle', 'hay' or 'separator'; should be a comma-separated list (no spaces!)
+    -p, --print         Print 'needle', 'hay', 'umatchedneedle' or 'separator'; should be a comma-separated list (no spaces!)
+
+# Examples
+
+## Find images in a large directory
+
+find-dups ~/photos img1.jpg img2.jpg
+
+## Compare two directories
+
+find-dups --reverse -p umatchedneedle dir1 dir2
 
 # Why?
 

--- a/bin/find-dups
+++ b/bin/find-dups
@@ -68,6 +68,10 @@ def parse_options(args)
       options[:print] = list
     end
 
+    opts.on("-r", "--reverse", "Also search for haystack in the needles") do |v|
+      options[:reverse] = true
+    end
+
     opts.on("-v", "--[no-]verbose", "Run verbosely") do |v|
       options[:verbose] = v
     end
@@ -97,6 +101,7 @@ end
 options = parse_options(ARGV)
 
 VERBOSE = options[:verbose]
+REVERSE = options[:reverse]
 PRINT_HAY = options[:print].include? 'hay'
 PRINT_UNMATCHEDNEEDLE = options[:print].include? 'umatchedneedle'
 PRINT_NEEDLE = options[:print].include? 'needle'
@@ -165,16 +170,25 @@ def print_needle(needle, found)
   puts if PRINT_SEPARATOR
 end
 
-info "Searching #{HAYSTACK_GLOB} for files equal to #{NEEDLES_GLOB}."
+def search(haystack, needles)
+  info "Searching #{haystack} for files equal to #{needles}."
 
-info_with_ellips 'Indexing haystack by file size'
-haystack = index_haystack(HAYSTACK_GLOB)
-haystack[0] = nil # ignore empty files
-info "#{haystack.size} files"
+  info_with_ellips 'Indexing haystack by file size'
+  indexed_haystack = index_haystack(haystack)
+  indexed_haystack[0] = nil # ignore empty files
+  info "#{indexed_haystack.size} files"
 
-info 'Comparing...'
-all_files(*NEEDLES_GLOB).each do |needle|
-  info "  examining #{needle}"
-  found = find_needle(needle, haystack)
-  print_needle(needle, found)
+  info 'Comparing...'
+  all_files(*needles).each do |needle|
+    info "  examining #{needle}"
+    found = find_needle(needle, indexed_haystack)
+    print_needle(needle, found)
+  end
+end
+
+search(HAYSTACK_GLOB, NEEDLES_GLOB)
+
+if REVERSE
+  info 'Comparing reverse...'
+  search(NEEDLES_GLOB, HAYSTACK_GLOB)
 end

--- a/bin/find-dups
+++ b/bin/find-dups
@@ -37,7 +37,7 @@ def wrap_text(*args)
   lines.join("\n")
 end
 
-ALLOWED_PRINT_OPTIONS = %w(hay needle separator)
+ALLOWED_PRINT_OPTIONS = %w(hay needle separator umatchedneedle)
 
 def parse_options(args)
   options = {}
@@ -61,8 +61,9 @@ def parse_options(args)
       "When a match is found, print needle, or",
       "hay, or both. PROPERTIES is a comma-",
       "separated list with one or more of the",
-      "words 'needle', 'hay', or 'separator'.",
-      "'separator' prints an empty line.",
+      "words 'needle', 'hay', 'umatchedneedle'.",
+      "Additionally 'separator' can be used to",
+      "print an empty line.",
       "Default: 'needle,hay'") do |list|
       options[:print] = list
     end
@@ -84,7 +85,7 @@ def parse_options(args)
   raise ArgumentError, "Missing HAYSTACK" if options[:haystack].nil?
   raise ArgumentError, "Missing NEEDLES" if options[:needles].empty?
   unless options[:print].all? { |option| ALLOWED_PRINT_OPTIONS.include? option }
-    raise ArgumentError, "Allowed print options are  'needle', 'hay', 'separator'"
+    raise ArgumentError, "Allowed print options are  'needle', 'hay', 'separator', 'umatchedneedle"
   end
 
   options
@@ -97,6 +98,7 @@ options = parse_options(ARGV)
 
 VERBOSE = options[:verbose]
 PRINT_HAY = options[:print].include? 'hay'
+PRINT_UNMATCHEDNEEDLE = options[:print].include? 'umatchedneedle'
 PRINT_NEEDLE = options[:print].include? 'needle'
 PRINT_SEPARATOR = options[:print].include? 'separator'
 
@@ -150,11 +152,14 @@ end
 BOLD = "\033[1m"
 NORMAL = "\033[22m"
 
-def print_found(needle, found)
-  if PRINT_NEEDLE
+def print_needle(needle, found)
+  if PRINT_NEEDLE or (PRINT_UNMATCHEDNEEDLE and found.nil?)
     print BOLD if $stdout.tty?
     puts needle
     print NORMAL if $stdout.tty?
+  end
+  if PRINT_HAY and (PRINT_UNMATCHEDNEEDLE and found.nil?)
+    puts "[UNMATCHED]"
   end
   puts found if PRINT_HAY
   puts if PRINT_SEPARATOR
@@ -171,5 +176,5 @@ info 'Comparing...'
 all_files(*NEEDLES_GLOB).each do |needle|
   info "  examining #{needle}"
   found = find_needle(needle, haystack)
-  print_found(needle, found) unless found.nil?
+  print_needle(needle, found)
 end


### PR DESCRIPTION
Added, and documented, two functions:

* print unmatchedneedle: prints the needle only when it isn't matched (if hay is given, it will print `[UNMATCHED]`
* added a `--reverse` option, that flips the haystack and the needle for 2-way comparison